### PR TITLE
Add Artifactory LDAP users report for permissions PR builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
 		stage ('Build') {
 			steps {
 				sh 'docker build permissions-report -t permissions-report'
+				sh 'docker build artifactory-users-report -t artifactory-users-report'
 			}
 		}
 		stage ('Run') {
@@ -17,9 +18,12 @@ pipeline {
 				}
 			}
 			steps {
-				sh 'docker run -e GITHUB_API_TOKEN=$GITHUB_API_TOKEN permissions-report > github-jenkinsci-permissions-report.json'
+				withCredentials([usernameColonPassword(credentialsId: 'artifactoryAdmin', variable: 'ARTIFACTORY_AUTH')]) {
+					sh 'docker run -e ARTIFACTORY_AUTH=$ARTIFACTORY_AUTH permissions-report > artifactory-ldap-users-report.json'
+				}
+				// TODO: sh 'docker run -e GITHUB_API_TOKEN=$GITHUB_API_TOKEN permissions-report > github-jenkinsci-permissions-report.json'
 				archiveArtifacts '*.json'
-				publishReports ([ 'github-jenkinsci-permissions-report.json' ])
+				publishReports ([ /*'github-jenkinsci-permissions-report.json',*/ 'artifactory-ldap-users-report.json' ])
 			}
 		}
 	}

--- a/artifactory-users-report/Dockerfile
+++ b/artifactory-users-report/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:stable-slim
+
+RUN apt-get update
+RUN apt-get install -y wget curl
+
+COPY user-report.sh /
+
+ENTRYPOINT ["sh", "/user-report.sh"]

--- a/artifactory-users-report/user-report.sh
+++ b/artifactory-users-report/user-report.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+
+wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 || { echo "Failed to download jq" >&2 ; exit 1; }
+chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1; }
+
+curl -X GET -H 'Content-Length: 0' -u $ARTIFACTORY_AUTH "https://repo.jenkins-ci.org/api/security/users" > artifactory-users-raw.json
+./jq 'map(select(.realm | test("ldap"))) | [ .[].name ] | sort' artifactory-users-raw.json


### PR DESCRIPTION
Adds a report listing all users from LDAP known to Artifactory. Knowing this is required to effectively review PRs to https://github.com/jenkins-infra/repository-permissions-updater/ and having this report will allow us to automate the user name check.

Since the publishing of the other report doesn't work (need to figure out credentials binding), commented that out.

Not strictly a "GitHub" report, so will rename this repo. It's just general Jenkins infra reports, no need to separate into different repos, I think.