### PR TITLE
feat(permissions-report): use a nonspot VM agent

### DIFF
--- a/permissions-report/Jenkinsfile
+++ b/permissions-report/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     buildDiscarder logRotator(daysToKeepStr: '90')
   }
   agent {
-    label 'jnlp-linux-arm64'
+    label 'linux-arm64-nonspot'
   }
   stages {
     stage('Generate GitHub Permissions Report') {


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4826#issuecomment-3860160585

#### Testing done

Replay with one of the labels of the new nonspot Linux arm64 VM agent template: https://infra.ci.jenkins.io/job/reports/job/permissions-report/job/main/1463