### PR TITLE
feat(Jenkinsfile) add build report publishing for all infra-reports jobs  monitoring

### DIFF
--- a/artifactory-users-report/Jenkinsfile
+++ b/artifactory-users-report/Jenkinsfile
@@ -43,5 +43,10 @@ pipeline {
         }
       }
     }
+    stage('Publish build report') {
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   }
 }

--- a/fork-report/Jenkinsfile
+++ b/fork-report/Jenkinsfile
@@ -45,5 +45,10 @@ pipeline {
         }
       }
     }
+    stage('Publish build report') {
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   }
 }

--- a/jenkins-infra-data/Jenkinsfile
+++ b/jenkins-infra-data/Jenkinsfile
@@ -59,5 +59,10 @@ pipeline {
         }
       }
     }
+    stage('Publish build report') {
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   }
 }

--- a/jira-users-report/Jenkinsfile
+++ b/jira-users-report/Jenkinsfile
@@ -43,5 +43,10 @@ pipeline {
         }
       }
     }
+    stage('Publish build report') {
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   }
 }

--- a/maintainers-info-report/Jenkinsfile
+++ b/maintainers-info-report/Jenkinsfile
@@ -43,5 +43,10 @@ pipeline {
         }
       }
     }
+    stage('Publish build report') {
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   }
 }

--- a/permissions-report/Jenkinsfile
+++ b/permissions-report/Jenkinsfile
@@ -46,5 +46,10 @@ pipeline {
         }
       }
     }
+    stage('Publish build report') {
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   }
 }

--- a/plugin-health-scoring/Jenkinsfile
+++ b/plugin-health-scoring/Jenkinsfile
@@ -61,5 +61,11 @@ pipeline {
         }
       }
     }
+
+    stage('Publish build report') {
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   }
 }


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/5135

This PR adds a `publishBuildStatusReport()` stage to each of the 7 report jobs in this repo:

- `artifactory-users-report/Jenkinsfile`
- `fork-report/Jenkinsfile`
- `jenkins-infra-data/Jenkinsfile`
- `jira-users-report/Jenkinsfile`
- `maintainers-info-report/Jenkinsfile`
- `permissions-report/Jenkinsfile`
- `plugin-health-scoring/Jenkinsfile`
